### PR TITLE
add Odm checker

### DIFF
--- a/DependencyInjection/VdmHealthcheckExtension.php
+++ b/DependencyInjection/VdmHealthcheckExtension.php
@@ -52,6 +52,13 @@ class VdmHealthcheckExtension extends ConfigurableExtension
         ) {
             $loader->load('./checker/http.yml');
         }
+
+        if (
+            $this->isCheckerTypeEnabled('odm', $mergedConfig['readiness_checkers'])
+            || $this->isCheckerTypeEnabled('odm', $mergedConfig['liveness_checkers'])
+        ) {
+            $loader->load('./checker/odm.yml');
+        }
     }
 
     /**

--- a/Healthcheck/Checker/Odm/OdmChecker.php
+++ b/Healthcheck/Checker/Odm/OdmChecker.php
@@ -43,6 +43,6 @@ class OdmChecker extends AbstractChecker
      */
     public function serviceCheck(): bool
     {
-        return $this->client->selectDatabase($this->configuration->getDefaultDB())->command(['ping' => 1]);
+        return $this->client->selectDatabase($this->configuration->getDefaultDB())->command(['ping' => 1]) !== false;
     }
 }

--- a/Healthcheck/Checker/Odm/OdmChecker.php
+++ b/Healthcheck/Checker/Odm/OdmChecker.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Vdm\Bundle\HealthcheckBundle\Healthcheck\Checker\Odm;
+
+use Doctrine\ODM\MongoDB\Configuration;
+use MongoDB\Client;
+use Vdm\Bundle\HealthcheckBundle\Healthcheck\AbstractChecker;
+
+class OdmChecker extends AbstractChecker
+{
+    public const DEFAULT_ERROR_TYPE = 'ODM';
+
+    /**
+     * @var Client
+     */
+    protected $client;
+    /**
+     * @var Configuration
+     */
+    protected $configuration;
+
+    /**
+     * OdmChecker constructor.
+     * @param Client $client
+     *
+     */
+    public function __construct(Client $client, Configuration $configuration)
+    {
+        $this->client = $client;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getErrorType(): string
+    {
+        return self::DEFAULT_ERROR_TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function serviceCheck(): bool
+    {
+        return $this->client->selectDatabase($this->configuration->getDefaultDB())->command(['ping' => 1]);
+    }
+}

--- a/Healthcheck/Checker/Odm/OdmCheckerFactory.php
+++ b/Healthcheck/Checker/Odm/OdmCheckerFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Vdm\Bundle\HealthcheckBundle\Healthcheck\Checker\Odm;
+
+use Doctrine\ODM\MongoDB\Configuration;
+use MongoDB\Client;
+use Vdm\Bundle\HealthcheckBundle\Exception\HealthcheckFactoryInvalidConfigurationException;
+use Vdm\Bundle\HealthcheckBundle\Healthcheck\AbstractChecker;
+use Vdm\Bundle\HealthcheckBundle\Healthcheck\CheckerConfig;
+use Vdm\Bundle\HealthcheckBundle\Healthcheck\AbstractCheckerFactory;
+
+class OdmCheckerFactory extends AbstractCheckerFactory
+{
+    public const CHECKER_TYPE = 'odm';
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getType(): string
+    {
+        return static::CHECKER_TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function validate(CheckerConfig $config): void
+    {
+        if ($config->getType() !== self::CHECKER_TYPE) {
+            throw new HealthcheckFactoryInvalidConfigurationException(
+                sprintf('invalid checker config type %s. supported type is %s', $config->getType(), self::CHECKER_TYPE)
+            );
+        }
+
+        if (count($config->getArguments()) !== 2) {
+            throw new HealthcheckFactoryInvalidConfigurationException('odm checker only supports one argument');
+        }
+
+        if (!$config->getArguments()[0] instanceof Client) {
+            throw new HealthcheckFactoryInvalidConfigurationException(
+                'odm checker argument 1 is not an instance of MongoDB\Client'
+            );
+        }
+
+        if (!$config->getArguments()[1] instanceof Configuration) {
+            throw new HealthcheckFactoryInvalidConfigurationException(
+                'odm checker argument 2 is not an instance of Doctrine\ODM\MongoDB\Configuration'
+            );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function instantiate(CheckerConfig $config): AbstractChecker
+    {
+        return new OdmChecker($config->getArguments()[0], $config->getArguments()[1]);
+    }
+}

--- a/Resources/config/checker/odm.yml
+++ b/Resources/config/checker/odm.yml
@@ -1,0 +1,11 @@
+parameters:
+
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+
+  Vdm\Bundle\HealthcheckBundle\Healthcheck\Checker\Odm\:
+    resource: '../../../Healthcheck/Checker/Odm/*'

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "phpunit/phpunit": "^8",
     "squizlabs/php_codesniffer": "3.*",
     "doctrine/doctrine-bundle": "^2.1",
+    "doctrine/mongodb-odm-bundle": "^4.2",
     "symfony/browser-kit": "^5.0",
     "symfony/css-selector": "^5.0",
     "symfony/http-client": "^5.0"


### PR DESCRIPTION
tester en local :     
`vdm_healthcheck:
  secret: ~
  liveness_path: /healthcheck
  liveness_checkers:
    my_odm:
      type: odm
      arguments:
        - '@doctrine_mongodb.odm.default_connection'
        - '@doctrine_mongodb.odm.default_configuration'
  readiness_path: /readiness
  readiness_checkers: {}`


  - error : `{"my_odm":{"up":false,"errorType":"ODM"}}`
  - success :` {"my_odm":{"up":true,"errorType":null}}`